### PR TITLE
Add l402-kit to implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ that work over open payment rails.
 * [Aperture](https://github.com/lightninglabs/aperture): gRPC/HTTP authentication reverse proxy using L402
 * [lsat-js](https://github.com/Tierion/lsat-js): JavaScript utility library for working with L402 credentials
 * [boltwall](https://github.com/tierion/boltwall): Node.js middleware-based authentication using L402
+* [l402-kit](https://github.com/ShinyDapps/l402-kit): Multi-language SDK (TypeScript, Python, Go, Rust) for adding L402 paywalls to any API in 3 lines of code
 
 ## External Links
 


### PR DESCRIPTION
l402-kit is an open-source multi-language SDK (TypeScript, Python, Go, Rust) 
that makes it easy to add L402 paywalls to any API in 3 lines of code.

- 1,800+ downloads/week on npm
- 1,300+ downloads/week on PyPI
- Supports managed and sovereign modes
- Works with AI agents (MCP, LangChain)

https://github.com/ShinyDapps/l402-kit
