### PR TITLE
docs: add l402-kit to implementations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ that work over open payment rails.
 * [Aperture](https://github.com/lightninglabs/aperture): gRPC/HTTP authentication reverse proxy using L402
 * [lsat-js](https://github.com/Tierion/lsat-js): JavaScript utility library for working with L402 credentials
 * [boltwall](https://github.com/tierion/boltwall): Node.js middleware-based authentication using L402
-* [l402-kit](https://github.com/ShinyDapps/l402-kit): TypeScript/Python/Go/Rust middleware for adding L402 to any API in 3 lines; includes AI agent SDK with budget controls, MCP server integration, and LangChain support
+* [l402-kit](https://github.com/ShinyDapps/l402-kit): Open-source L402 middleware for TypeScript, Python, Go, and Rust
 
 ## External Links
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ that work over open payment rails.
 * [Aperture](https://github.com/lightninglabs/aperture): gRPC/HTTP authentication reverse proxy using L402
 * [lsat-js](https://github.com/Tierion/lsat-js): JavaScript utility library for working with L402 credentials
 * [boltwall](https://github.com/tierion/boltwall): Node.js middleware-based authentication using L402
+* [l402-kit](https://github.com/ShinyDapps/l402-kit): TypeScript/Python/Go/Rust middleware for adding L402 to any API in 3 lines; includes AI agent SDK with budget controls, MCP server integration, and LangChain support
 
 ## External Links
 


### PR DESCRIPTION
Adds [l402-kit](https://github.com/ShinyDapps/l402-kit) to the Implementations section.

L402 middleware with TypeScript, Python, Go, and Rust SDKs (MIT).