### PR TITLE
docs: add l402-kit to implementations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ that work over open payment rails.
 * [Aperture](https://github.com/lightninglabs/aperture): gRPC/HTTP authentication reverse proxy using L402
 * [lsat-js](https://github.com/Tierion/lsat-js): JavaScript utility library for working with L402 credentials
 * [boltwall](https://github.com/tierion/boltwall): Node.js middleware-based authentication using L402
+* [l402-kit](https://github.com/ShinyDapps/l402-kit): Multi-language middleware (TypeScript, Python, Go, Rust) for L402 — compatible with Express, FastAPI, Flask, and Axum
 
 ## External Links
 


### PR DESCRIPTION
## Summary

[l402-kit](https://github.com/ShinyDapps/l402-kit) is an open-source L402 middleware covering TypeScript, Python, Go, and Rust - compatible with Express, FastAPI, Flask, and Axum. Implements the full L402 flow: HTTP 402 challenge -> BOLT11 invoice -> preimage verification (SHA256).

Also ships an MCP server so AI agents can autonomously pay L402-protected APIs without human intervention.

## Change

One line added to the `## Implementations` section in `README.md`, alongside Aperture, lsat-js, and boltwall.